### PR TITLE
Reorder sidebar and add IMN actions

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -77,10 +77,10 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const adminMenuItems = [
     { path: '/admin', icon: Home, label: 'Главная' },
     { path: '/admin/branches', icon: Building2, label: 'Филиалы' },
-    { path: '/admin/medicines', icon: Package, label: 'Лекарства' },
-    { path: '/admin/medical-devices', icon: Package, label: 'ИМН' },
     { path: '/admin/medicine-categories', icon: FileText, label: 'Категории лекарств' },
     { path: '/admin/medical-devices-categories', icon: FileText, label: 'Категории ИМН' },
+    { path: '/admin/medicines', icon: Package, label: 'Лекарства' },
+    { path: '/admin/medical-devices', icon: Package, label: 'ИМН' },
     { path: '/admin/arrivals', icon: Truck, label: 'Поступления' },
     { path: '/admin/shipments', icon: ArrowLeftRight, label: 'Отправки' },
     { path: '/admin/employees', icon: Users, label: 'Сотрудники' },


### PR DESCRIPTION
## Summary
- Reorder admin sidebar menu to place device and medicine categories before item lists
- Add edit and delete actions for medical devices list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 169 errors, 20 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b425773e148328afd73734acfd9a70