### PR TITLE
Reorder sidebar and add IMN actions

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -77,10 +77,10 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const adminMenuItems = [
     { path: '/admin', icon: Home, label: 'Главная' },
     { path: '/admin/branches', icon: Building2, label: 'Филиалы' },
-    { path: '/admin/medicines', icon: Package, label: 'Лекарства' },
-    { path: '/admin/medical-devices', icon: Package, label: 'ИМН' },
     { path: '/admin/medicine-categories', icon: FileText, label: 'Категории лекарств' },
     { path: '/admin/medical-devices-categories', icon: FileText, label: 'Категории ИМН' },
+    { path: '/admin/medicines', icon: Package, label: 'Лекарства' },
+    { path: '/admin/medical-devices', icon: Package, label: 'ИМН' },
     { path: '/admin/arrivals', icon: Truck, label: 'Поступления' },
     { path: '/admin/shipments', icon: ArrowLeftRight, label: 'Отправки' },
     { path: '/admin/employees', icon: Users, label: 'Сотрудники' },

--- a/src/pages/admin/MedicalDevices.tsx
+++ b/src/pages/admin/MedicalDevices.tsx
@@ -27,8 +27,9 @@ const AdminMedicalDevices: React.FC = () => {
   const [devices, setDevices] = useState<Device[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
-  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [newDevice, setNewDevice] = useState({
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingDevice, setEditingDevice] = useState<Device | null>(null);
+  const [formData, setFormData] = useState({
     name: '',
     category_id: '',
     purchase_price: 0,
@@ -56,28 +57,78 @@ const AdminMedicalDevices: React.FC = () => {
     }
   };
 
-  const handleCreateDevice = async () => {
-    if (!newDevice.name || !newDevice.category_id || !newDevice.purchase_price || !newDevice.quantity) {
+  const resetForm = () => {
+    setFormData({ name: '', category_id: '', purchase_price: 0, quantity: 0 });
+    setEditingDevice(null);
+  };
+
+  const handleSubmit = async () => {
+    if (!formData.name || !formData.category_id || !formData.purchase_price || !formData.quantity) {
       toast({
         title: 'Ошибка',
         description: 'Заполните все поля и выберите категорию',
-        variant: 'destructive'
+        variant: 'destructive',
       });
       return;
     }
+
     try {
-      const payload = { ...newDevice, sell_price: 0 };
-      const result = await apiService.createMedicalDevice(payload);
-      if (result.data) {
-        setDevices([...devices, result.data as Device]);
-        setNewDevice({ name: '', category_id: '', purchase_price: 0, quantity: 0 });
-        setIsCreateDialogOpen(false);
-        toast({ title: 'Успешно', description: 'ИМН создано' });
+      const payload = { ...formData, sell_price: 0 };
+      if (editingDevice) {
+        const result = await apiService.updateMedicalDevice(editingDevice.id, payload);
+        if (!result.error) {
+          setDevices((prev) =>
+            prev.map((d) => (d.id === editingDevice.id ? { ...payload, id: editingDevice.id } : d))
+          );
+          toast({ title: 'Успешно', description: 'ИМН обновлено' });
+        } else {
+          toast({ title: 'Ошибка', description: result.error, variant: 'destructive' });
+        }
       } else {
-        toast({ title: 'Ошибка', description: result.error, variant: 'destructive' });
+        const result = await apiService.createMedicalDevice(payload);
+        if (result.data) {
+          setDevices((prev) => [...prev, result.data as Device]);
+          toast({ title: 'Успешно', description: 'ИМН создано' });
+        } else {
+          toast({ title: 'Ошибка', description: result.error, variant: 'destructive' });
+        }
       }
+
+      setIsDialogOpen(false);
+      resetForm();
     } catch (error) {
-      toast({ title: 'Ошибка', description: 'Не удалось создать ИМН', variant: 'destructive' });
+      toast({
+        title: 'Ошибка',
+        description: editingDevice ? 'Не удалось обновить ИМН' : 'Не удалось создать ИМН',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleEdit = (device: Device) => {
+    setEditingDevice(device);
+    setFormData({
+      name: device.name,
+      category_id: device.category_id,
+      purchase_price: device.purchase_price,
+      quantity: device.quantity,
+    });
+    setIsDialogOpen(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (confirm('Вы уверены, что хотите удалить это ИМН?')) {
+      try {
+        const result = await apiService.deleteMedicalDevice(id);
+        if (!result.error) {
+          setDevices((prev) => prev.filter((d) => d.id !== id));
+          toast({ title: 'Успешно', description: 'ИМН удалено' });
+        } else {
+          toast({ title: 'Ошибка', description: result.error, variant: 'destructive' });
+        }
+      } catch (error) {
+        toast({ title: 'Ошибка', description: 'Не удалось удалить ИМН', variant: 'destructive' });
+      }
     }
   };
 
@@ -87,37 +138,66 @@ const AdminMedicalDevices: React.FC = () => {
     <div className="p-6 space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">Изделия медицинского назначения</h1>
-        <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+        <Dialog
+          open={isDialogOpen}
+          onOpenChange={(open) => {
+            setIsDialogOpen(open);
+            if (!open) resetForm();
+          }}
+        >
           <DialogTrigger asChild>
-            <Button><Plus className="h-4 w-4 mr-2" />Добавить ИМН</Button>
+            <Button>
+              <Plus className="h-4 w-4 mr-2" />Добавить ИМН
+            </Button>
           </DialogTrigger>
           <DialogContent>
-            <DialogHeader><DialogTitle>Создать новое ИМН</DialogTitle></DialogHeader>
+            <DialogHeader>
+              <DialogTitle>{editingDevice ? 'Редактировать ИМН' : 'Создать новое ИМН'}</DialogTitle>
+            </DialogHeader>
             <div className="space-y-4">
               <div>
                 <Label>Название</Label>
-                <Input value={newDevice.name} onChange={(e) => setNewDevice({ ...newDevice, name: e.target.value })} />
+                <Input value={formData.name} onChange={(e) => setFormData({ ...formData, name: e.target.value })} />
               </div>
               <div>
                 <Label>Категория</Label>
-                <Select value={newDevice.category_id} onValueChange={(value) => setNewDevice({ ...newDevice, category_id: value })}>
-                  <SelectTrigger><SelectValue placeholder="Выберите категорию" /></SelectTrigger>
+                <Select value={formData.category_id} onValueChange={(value) => setFormData({ ...formData, category_id: value })}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Выберите категорию" />
+                  </SelectTrigger>
                   <SelectContent>
                     {categories.map((cat) => (
-                      <SelectItem key={cat.id} value={cat.id}>{cat.name}</SelectItem>
+                      <SelectItem key={cat.id} value={cat.id}>
+                        {cat.name}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
               </div>
               <div>
                 <Label>Цена закупки</Label>
-                <Input type="number" value={newDevice.purchase_price} onChange={(e) => setNewDevice({ ...newDevice, purchase_price: Number(e.target.value) })} />
+                <Input
+                  type="number"
+                  value={formData.purchase_price}
+                  onChange={(e) => setFormData({ ...formData, purchase_price: Number(e.target.value) })}
+                />
               </div>
               <div>
                 <Label>Количество</Label>
-                <Input type="number" value={newDevice.quantity} onChange={(e) => setNewDevice({ ...newDevice, quantity: Number(e.target.value) })} />
+                <Input
+                  type="number"
+                  value={formData.quantity}
+                  onChange={(e) => setFormData({ ...formData, quantity: Number(e.target.value) })}
+                />
               </div>
-              <Button onClick={handleCreateDevice} className="w-full">Создать ИМН</Button>
+              <div className="flex space-x-2">
+                <Button onClick={handleSubmit} className="flex-1">
+                  {editingDevice ? 'Обновить' : 'Создать'}
+                </Button>
+                <Button variant="outline" onClick={() => setIsDialogOpen(false)} className="flex-1">
+                  Отмена
+                </Button>
+              </div>
             </div>
           </DialogContent>
         </Dialog>
@@ -127,19 +207,34 @@ const AdminMedicalDevices: React.FC = () => {
         <CardHeader><CardTitle>Список ИМН ({devices.length})</CardTitle></CardHeader>
         <CardContent>
           <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Название</TableHead>
-                  <TableHead>Количество</TableHead>
-                  <TableHead>Цена закупки</TableHead>
-                </TableRow>
-              </TableHeader>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Название</TableHead>
+                <TableHead>Количество</TableHead>
+                <TableHead>Цена закупки</TableHead>
+                <TableHead>Действия</TableHead>
+              </TableRow>
+            </TableHeader>
             <TableBody>
               {devices.map((device) => (
                 <TableRow key={device.id}>
                   <TableCell>{device.name}</TableCell>
                   <TableCell>{device.quantity}</TableCell>
                   <TableCell>{device.purchase_price}₸</TableCell>
+                  <TableCell>
+                    <div className="flex space-x-2">
+                      <Button size="sm" variant="outline" onClick={() => handleEdit(device)}>
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => handleDelete(device.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>


### PR DESCRIPTION
## Summary
- reorder admin sidebar so categories precede medicines
- add edit & delete actions to IMN list with modal form

## Testing
- `npm run lint` *(fails: Unexpected any, react-refresh warnings, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b42946c24c8328a26a839aaeab8c1e