### PR TITLE
fix(fe): normalize getArrivals response shape; guard rendering to prevent .map crash

### DIFF
--- a/src/pages/admin/Arrivals.tsx
+++ b/src/pages/admin/Arrivals.tsx
@@ -37,7 +37,7 @@ const AdminArrivals: React.FC = () => {
 
   const fetchArrivals = async () => {
     const res = await apiService.getArrivals(activeTab);
-    if (res.data) setArrivals(res.data);
+    setArrivals(res.data);
   };
 
   const addRow = (type: ItemType) => {
@@ -109,7 +109,7 @@ const AdminArrivals: React.FC = () => {
 
       <h2>Arrivals</h2>
       <ul>
-        {arrivals.map((a) => (
+        {(arrivals ?? []).map((a) => (
           <li key={a.id}>
             {a.item_name} - {a.quantity}
           </li>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -198,9 +198,18 @@ class ApiService {
 
   // Arrivals
   // GET arrivals (optional filter by type)
-  getArrivals(itemType?: string) {
+  async getArrivals(itemType?: string) {
     const params = itemType ? `?item_type=${itemType}` : '';
-    return this.request<any[]>(`/arrivals${params}`);
+    const res = await this.request<any>(`/arrivals${params}`);
+
+    // Normalize to array
+    if (Array.isArray(res?.data)) {
+      return { data: res.data };
+    }
+    if (Array.isArray(res?.data?.data)) {
+      return { data: res.data.data };
+    }
+    return { data: [] as any[] };
   }
 
   // POST arrivals


### PR DESCRIPTION
## Summary
- Normalize `getArrivals` API response to always return an array
- Use normalized arrivals array and render with fallback to prevent `.map` errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5365c0ba08328aeae4b09b5a701ed