### PR TITLE
feat: fix arrivals selection and payload handling

### DIFF
--- a/src/components/ReceiptRowItem.tsx
+++ b/src/components/ReceiptRowItem.tsx
@@ -1,95 +1,76 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Trash2 } from 'lucide-react';
+import type { ItemType, CatalogItem } from '@/pages/admin/Arrivals';
 
 export interface ReceiptRow {
   id: string;
-  itemType: 'medicine' | 'medical_device';
+  itemType: ItemType;        // 'medicine' | 'medical_device' (derived, not editable)
   itemId: string | null;
   itemName: string;
   qty: number;
 }
 
-interface CatalogItem {
-  id: string;
-  name: string;
-  quantity?: number;
-  branch_id?: string | null;
-}
-
-interface ReceiptRowItemProps {
+type Props = {
   row: ReceiptRow;
   medicines: CatalogItem[];
   devices: CatalogItem[];
+  activeTab: ItemType;
   onUpdate: (id: string, field: keyof ReceiptRow, value: unknown) => void;
   onRemove: (id: string) => void;
-  activeTab: 'medicine' | 'medical_device';
-}
+};
 
-const ReceiptRowItem: React.FC<ReceiptRowItemProps> = ({
+const ReceiptRowItem: React.FC<Props> = ({
   row,
   medicines,
   devices,
+  activeTab,
   onUpdate,
   onRemove,
-  activeTab,
 }) => {
-  const options = activeTab === 'medicine' ? medicines : devices;
+  const options = row.itemType === 'medicine' ? medicines : devices;
+  const placeholder = activeTab === 'medicine' ? 'Выберите лекарство' : 'Выберите ИМН';
+  const label = activeTab === 'medicine' ? 'Лекарство' : 'ИМН';
+
+  const handleSelect = (val: string) => {
+    const item = options.find((i) => i.id === val);
+    onUpdate(row.id, 'itemId', val);
+    onUpdate(row.id, 'itemName', item?.name ?? '');
+  };
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-gray-50 rounded-lg">
-      <div>
-        <Label>{activeTab === 'medicine' ? 'Лекарство' : 'ИМН'}</Label>
-        <Select
-          value={row.itemId ?? ''}
-          onValueChange={(val) => {
-            const item = options.find((i) => i.id === val);
-            onUpdate(row.id, 'itemId', val);
-            onUpdate(row.id, 'itemName', item?.name ?? '');
-          }}
-          disabled={options.length === 0}
-        >
+    <div className="grid grid-cols-12 gap-4 items-center">
+      <div className="col-span-5">
+        <div className="text-sm font-medium mb-1">{label}</div>
+        <Select value={row.itemId ?? ''} onValueChange={handleSelect}>
           <SelectTrigger>
-            <SelectValue
-              placeholder={activeTab === 'medicine' ? 'Выберите лекарство' : 'Выберите ИМН'}
-            />
+            <SelectValue placeholder={placeholder} />
           </SelectTrigger>
           <SelectContent>
             {options.map((o) => (
               <SelectItem key={o.id} value={o.id}>
-                {o.name} (текущее: {o.quantity ?? 0} шт.)
+                {o.name}{` (текущее: ${o.quantity ?? 0} шт.)`}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
       </div>
-      <div>
-        <Label>Количество</Label>
+
+      <div className="col-span-3">
+        <div className="text-sm font-medium mb-1">Количество</div>
         <Input
           type="number"
-          value={row.qty}
           min={1}
+          value={row.qty}
           onChange={(e) =>
             onUpdate(row.id, 'qty', Math.max(1, Number(e.target.value) || 0))
           }
         />
       </div>
-      <div className="flex items-end">
-        <Button
-          variant="destructive"
-          onClick={() => onRemove(row.id)}
-          className="w-full"
-        >
-          <Trash2 className="h-4 w-4 mr-2" />
+
+      <div className="col-span-4 flex justify-end items-end">
+        <Button variant="destructive" onClick={() => onRemove(row.id)}>
           Удалить
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- derive item type from active tab and remove per-row type selector
- control item selection and quantity inputs for medicines and devices
- post arrivals without prices

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b55df185808328b966562109a2dde3