### PR TITLE
Fix dispensing payload format

### DIFF
--- a/src/pages/branch/Dispensing.tsx
+++ b/src/pages/branch/Dispensing.tsx
@@ -117,17 +117,21 @@ const Dispensing: React.FC = () => {
       return;
     }
 
-    const employee = employees.find((e) => e.id === selectedEmployee);
-    const patient = patients.find((p) => p.id === selectedPatient);
+    // Build items for API: only positive quantities
+    const items = [
+      ...selectedMedicines
+        .filter((r) => r.medicineId && r.quantity > 0)
+        .map((r) => ({ type: 'medicine' as const, item_id: r.medicineId, quantity: r.quantity })),
+      ...selectedDevices
+        .filter((r) => r.deviceId && r.quantity > 0)
+        .map((r) => ({ type: 'medical_device' as const, item_id: r.deviceId, quantity: r.quantity })),
+    ];
 
     const payload = {
       patient_id: selectedPatient,
-      patient_name: patient ? `${patient.first_name} ${patient.last_name}` : '',
       employee_id: selectedEmployee,
-      employee_name: employee ? `${employee.first_name} ${employee.last_name}` : '',
-      branch_id: branchId,
-      medicines: medicinesPayload,
-      medical_devices: devicesPayload,
+      branch_id: branchId!,
+      items,
     };
 
     try {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -415,12 +415,9 @@ class ApiService {
   // Create dispensing record
   async createDispensingRecord(body: {
     patient_id: string;
-    patient_name: string;
     employee_id: string;
-    employee_name: string;
     branch_id: string;
-    medicines: { id: string; name: string; quantity: number }[];
-    medical_devices: { id: string; name: string; quantity: number }[];
+    items: { type: 'medicine' | 'medical_device'; item_id: string; quantity: number }[];
   }) {
     return this.request<any>('/dispensing', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- build unified items payload for dispensing, filtering out zero-quantity selections
- update API client to send patient, employee, branch IDs with item list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b5b43fa91483288730aac98c3e004f