### PR TITLE
Handle dispensing payload and improve error handling

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -237,10 +237,6 @@ class DispensePayload(BaseModel):
             normalized.append(
                 DispenseLine(item_id=d.id, quantity=d.quantity, item_type="medical_device")
             )
-
-        if not normalized:
-            raise ValueError("No items to dispense")
-
         object.__setattr__(self, "_normalized_items", normalized)
         return self
 

--- a/src/pages/branch/Dispensing.tsx
+++ b/src/pages/branch/Dispensing.tsx
@@ -126,7 +126,19 @@ const Dispensing: React.FC = () => {
     try {
       const response = await apiService.createDispensingRecord(payload);
       if (response.error) {
-        toast({ title: 'Ошибка', description: response.error, variant: 'destructive' });
+        try {
+          const detail = JSON.parse(response.error);
+          if (detail.code === 'insufficient_stock') {
+            const msg = detail.items
+              .map((i: any) => `${i.type}: запрошено ${i.requested}, доступно ${i.available}`)
+              .join('\n');
+            toast({ title: 'Недостаточно товаров', description: msg, variant: 'destructive' });
+          } else {
+            toast({ title: 'Ошибка', description: response.error, variant: 'destructive' });
+          }
+        } catch {
+          toast({ title: 'Ошибка', description: response.error, variant: 'destructive' });
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- Normalize new and legacy dispensing payloads server-side and validate stock atomically
- Improve API request helper to parse empty/error responses
- Surface insufficient stock errors on dispensing page

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6fb29ef1083288527339d3cdbc198