### PR TITLE
feat: add stock report with item details

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,3 +103,18 @@ export interface DispensingRecord {
   medicines?: Array<{medicine_name: string, quantity: number}>;
   medical_devices?: Array<{device_name: string, quantity: number}>;
 }
+
+export interface StockRow {
+  type: 'medicine' | 'medical_device';
+  id: string;
+  name: string;
+  category_name: string;
+  quantity: number;
+}
+
+export interface StockDetails {
+  incoming: Array<{ date: string; qty: number }>;
+  outgoing: Array<{ date: string; qty: number }>;
+  total_in: number;
+  total_out: number;
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -534,6 +534,26 @@ class ApiService {
     });
   }
 
+  async getStockReport(params: { branch_id: string; date_from?: string; date_to?: string }) {
+    const q = new URLSearchParams(params as any).toString();
+    const res = await this.request<any>(`/reports/stock?${q}`);
+    if (res.error) return res;
+    return { data: this.normalizeData(res) };
+  }
+
+  async getStockItemDetails(params: {
+    branch_id: string;
+    type: 'medicine' | 'medical_device';
+    item_id: string;
+    date_from?: string;
+    date_to?: string;
+  }) {
+    const q = new URLSearchParams(params as any).toString();
+    const res = await this.request<any>(`/reports/stock/item_details?${q}`);
+    if (res.error) return res;
+    return { data: this.normalizeData(res) };
+  }
+
   // Mark calendar event as dispensed
   async markDispensedOnCalendar(patientId: string, dateISO: string) {
     return this.request<any>('/calendar/mark-dispensed', {


### PR DESCRIPTION
## Summary
- add unified stock report endpoint and item detail endpoint for medicines and devices
- expose stock report APIs to frontend
- implement stock report UI with item movement modal

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bd1cc6478c8328b71023403288c83e