### PR TITLE
feat: add incoming report

### DIFF
--- a/backend/tests/test_dispensing.py
+++ b/backend/tests/test_dispensing.py
@@ -9,7 +9,10 @@ import pathlib
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-os.environ["DATABASE_URL"] = "sqlite:///./test_dispense.db"
+DB_PATH = "./test_dispense.db"
+if os.path.exists(DB_PATH):
+    os.remove(DB_PATH)
+os.environ["DATABASE_URL"] = f"sqlite:///{DB_PATH}"
 
 from database import (
     create_tables,

--- a/backend/tests/test_incoming_report.py
+++ b/backend/tests/test_incoming_report.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import asyncio
+from datetime import datetime
+from sqlalchemy import text
+import pathlib
+import importlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+DB_PATH = "./test_incoming_report.db"
+if os.path.exists(DB_PATH):
+    os.remove(DB_PATH)
+os.environ["DATABASE_URL"] = f"sqlite:///{DB_PATH}"
+
+import database
+importlib.reload(database)
+from database import create_tables, SessionLocal, Branch, Shipment, ShipmentItem
+from main import get_incoming_report
+
+create_tables()
+session = SessionLocal()
+session.add(Branch(id="b1", name="B1", login="b1", password="p"))
+session.commit()
+
+
+def test_incoming_report():
+    session.execute(text("DELETE FROM shipment_items"))
+    session.execute(text("DELETE FROM shipments"))
+    session.commit()
+
+    session.add(Shipment(id="s1", to_branch_id="b1", status="accepted", created_at=datetime(2024, 1, 10, 12, 0, 0)))
+    session.add(ShipmentItem(id="i1", shipment_id="s1", item_type="medicine", item_id="m1", item_name="Тримол", quantity=20))
+    session.add(ShipmentItem(id="i2", shipment_id="s1", item_type="medical_device", item_id="d1", item_name="Шприц 100", quantity=15))
+
+    session.add(Shipment(id="s2", to_branch_id="b1", status="accepted", created_at=datetime(2024, 2, 1, 10, 0, 0)))
+    session.add(ShipmentItem(id="i3", shipment_id="s2", item_type="medicine", item_id="m1", item_name="Тест", quantity=5))
+
+    session.add(Shipment(id="s3", to_branch_id="b1", status="pending", created_at=datetime(2024, 1, 20, 10, 0, 0)))
+    session.add(ShipmentItem(id="i4", shipment_id="s3", item_type="medicine", item_id="m1", item_name="Тест2", quantity=1))
+
+    session.commit()
+
+    resp = asyncio.run(get_incoming_report("b1", "2024-01-01", "2024-01-31", db=session))
+    assert len(resp["data"]) == 1
+    entry = resp["data"][0]
+    assert entry["id"] == "s1"
+    assert len(entry["items"]) == 2
+    names = {i["name"] for i in entry["items"]}
+    assert "Тримол" in names and "Шприц 100" in names

--- a/src/pages/branch/BranchReports.tsx
+++ b/src/pages/branch/BranchReports.tsx
@@ -54,7 +54,7 @@ const BranchReports: React.FC = () => {
           response = await apiService.getDispensingReport(params as any);
           break;
         case 'arrivals':
-          response = await apiService.getArrivals();
+          response = await apiService.getIncomingReport(params as any);
           break;
         default:
           throw new Error('Unknown report type');
@@ -172,6 +172,38 @@ const BranchReports: React.FC = () => {
                 <TableCell>
                   {new Date(row.datetime).toLocaleString('ru-RU', { timeZone: 'Asia/Almaty' })}
                 </TableCell>
+                <TableCell>
+                  <Button variant="outline" size="sm" onClick={() => showItemDetails(row)}>
+                    Подробнее
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      );
+    }
+
+    if (selectedReportType === 'arrivals') {
+      const summarize = (items: any[]) => {
+        const parts = items.map((i: any) => `${i.name} — ${i.quantity} шт.`);
+        const res = parts.slice(0, 3).join('; ');
+        return parts.length > 3 ? `${res}; …` : res;
+        };
+      return (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Дата</TableHead>
+              <TableHead>Состав поступления</TableHead>
+              <TableHead>Действия</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {reportData.map((row: any) => (
+              <TableRow key={row.id}>
+                <TableCell>{new Date(row.datetime).toLocaleString('ru-RU', { timeZone: 'Asia/Almaty' })}</TableCell>
+                <TableCell>{summarize(row.items)}</TableCell>
                 <TableCell>
                   <Button variant="outline" size="sm" onClick={() => showItemDetails(row)}>
                     Подробнее
@@ -310,7 +342,7 @@ const BranchReports: React.FC = () => {
           <CardContent className="text-center py-8">
             <FileText className="h-16 w-16 mx-auto mb-4 text-muted-foreground" />
             <p className="text-muted-foreground">
-              {selectedReportType === 'dispensing'
+              {selectedReportType === 'dispensing' || selectedReportType === 'arrivals'
                 ? 'Нет данных за выбранный период.'
                 : 'Нет данных для отображения. Попробуйте изменить параметры отчета.'}
             </p>
@@ -326,7 +358,9 @@ const BranchReports: React.FC = () => {
                 ? 'Детали по остатку'
                 : selectedReportType === 'dispensing'
                   ? 'Состав выдачи'
-                  : 'Детали'}
+                  : selectedReportType === 'arrivals'
+                    ? 'Состав поступления'
+                    : 'Детали'}
             </DialogTitle>
           </DialogHeader>
           {selectedReportType === 'stock' && stockDetails ? (
@@ -378,7 +412,7 @@ const BranchReports: React.FC = () => {
                 </div>
               </div>
             )
-          ) : selectedReportType === 'dispensing' && selectedItem ? (
+          ) : (selectedReportType === 'dispensing' || selectedReportType === 'arrivals') && selectedItem ? (
             selectedItem.items && selectedItem.items.length > 0 ? (
               <Table>
                 <TableHeader>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -130,3 +130,13 @@ export interface DispensingRow {
     quantity: number;
   }>;
 }
+
+export interface IncomingRow {
+  id: string;
+  datetime: string;
+  items: Array<{
+    type: 'medicine' | 'medical_device';
+    name: string;
+    quantity: number;
+  }>;
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,4 @@
-import type { DispensingRow } from '@/types';
+import type { DispensingRow, IncomingRow } from '@/types';
 
 const API_BASE_URL = 'http://localhost:8000';
 
@@ -541,6 +541,13 @@ class ApiService {
     const res = await this.request<any>(`/reports/dispensing?${q}`);
     if (res.error) return res as any;
     return { data: this.normalizeData(res) } as { data: DispensingRow[] };
+  }
+
+  async getIncomingReport(params: { branch_id: string; date_from: string; date_to: string }): Promise<{ data: IncomingRow[] }> {
+    const q = new URLSearchParams(params as any).toString();
+    const res = await this.request<any>(`/reports/incoming?${q}`);
+    if (res.error) return res as any;
+    return { data: this.normalizeData(res) } as { data: IncomingRow[] };
   }
 
   async getStockReport(params: { branch_id: string; date_from?: string; date_to?: string }) {


### PR DESCRIPTION
## Summary
- add backend endpoint for incoming shipments report with filtering
- expose getIncomingReport in api service and wire up branch UI
- cover incoming report with tests

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bd230b52ec8328b42c282f115def6a