### PR TITLE
Implement dated stock report and streamline branch UI

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,10 +105,10 @@ export interface DispensingRecord {
 }
 
 export interface StockRow {
-  type: 'medicine' | 'medical_device';
-  id: string;
+  item_type: 'medicine' | 'medical_device';
+  item_id: string;
   name: string;
-  category_name: string;
+  category: string;
   quantity: number;
 }
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -550,12 +550,10 @@ class ApiService {
     return { data: this.normalizeData(res) } as { data: IncomingRow[] };
   }
 
-  async getStockReport(branchId: string, dateFrom?: string, dateTo?: string) {
-    const qs = new URLSearchParams({ branch_id: branchId });
-    if (dateFrom) qs.set('date_from', dateFrom);
-    if (dateTo) qs.set('date_to', dateTo);
-    const res = await this.request<any>(`/reports/stock?${qs.toString()}`);
-    if (res.error) return res;
+  async getStockReport(params: { branch_id: string; date_from?: string; date_to?: string }) {
+    const qs = new URLSearchParams(params as any).toString();
+    const res = await this.request<any>(`/reports/stock?${qs}`);
+    if (res.error) return res as any;
     return { data: this.normalizeData(res) };
   }
 


### PR DESCRIPTION
## Summary
- compute branch stock with current or closing balance paths, merging medicines and devices with categories
- expose helper to pick branch column and adjust Excel export
- simplify branch stock report UI: remove details column, map export columns, and send optional date range

## Testing
- ✅ `pytest`
- ⚠️ `npm test` (script missing)
- ⚠️ `npm run lint` (missing package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68bd471a5d74832886ef2643f3d35563