### PR TITLE
feat: export dispensing report to excel

### DIFF
--- a/src/pages/branch/BranchReports.tsx
+++ b/src/pages/branch/BranchReports.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { apiService } from '@/utils/api';
+import { apiService, API_BASE_URL } from '@/utils/api';
 import { storage } from '@/utils/storage';
 import { Calendar, Download, FileText, Package, Users, TrendingUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -81,6 +81,18 @@ const BranchReports: React.FC = () => {
   };
 
   const exportToExcel = () => {
+    if (selectedReportType === 'dispensing') {
+      const params = new URLSearchParams({
+        branch_id: branchId!,
+        date_from: dateFrom,
+        date_to: dateTo,
+        export: 'excel',
+      });
+      const url = `/reports/dispensings?${params.toString()}`;
+      window.open(`${API_BASE_URL}${url}`, '_blank');
+      return;
+    }
+
     if (reportData.length === 0) {
       toast({ title: 'Нет данных для экспорта', variant: 'destructive' });
       return;
@@ -102,10 +114,10 @@ const BranchReports: React.FC = () => {
     }
     const workbook = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(workbook, worksheet, 'Report');
-    
+
     const fileName = `${reportType?.label || 'Отчет'}_${new Date().toISOString().split('T')[0]}.xlsx`;
     XLSX.writeFile(workbook, fileName);
-    
+
     toast({ title: 'Отчет экспортирован в Excel' });
   };
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,6 +1,6 @@
 import type { DispensingRow, IncomingRow } from '@/types';
 
-const API_BASE_URL = 'http://localhost:8000';
+export const API_BASE_URL = 'http://localhost:8000';
 
 interface LoginData {
   login: string;
@@ -538,7 +538,7 @@ class ApiService {
 
   async getDispensingReport(params: { branch_id: string; date_from: string; date_to: string }): Promise<{ data: DispensingRow[] }> {
     const q = new URLSearchParams(params as any).toString();
-    const res = await this.request<any>(`/reports/dispensing?${q}`);
+    const res = await this.request<any>(`/reports/dispensings?${q}`);
     if (res.error) return res as any;
     return { data: this.normalizeData(res) } as { data: DispensingRow[] };
   }


### PR DESCRIPTION
## Summary
- add `/reports/dispensings` endpoint that groups items and generates Excel with Almaty timestamps
- expose API_BASE_URL and update client to hit new endpoint
- wire front-end export button to server-generated Excel

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bd4c0e6ba883289ea74afa48edcc3a