### PR TITLE
Implement warehouse stock report and improve frontend formatting

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -369,12 +369,11 @@ class ApiService {
   }
 
   // Warehouse reports
-  async getWarehouseStock(params: { dateFrom?: string; dateTo?: string }) {
+  async getWarehouseStock(params: { date_from?: string; date_to?: string }) {
     const qs = new URLSearchParams();
-    if (params.dateFrom) qs.set('date_from', params.dateFrom);
-    if (params.dateTo) qs.set('date_to', params.dateTo);
-    const res = await this.request<any>(`/admin/warehouse/reports/stock?${qs.toString()}`);
-    return res.data?.data ?? [];
+    if (params.date_from) qs.set('date_from', params.date_from);
+    if (params.date_to) qs.set('date_to', params.date_to);
+    return this.request<any>(`/admin/warehouse/reports/stock?${qs.toString()}`);
   }
 
   async getWarehouseArrivals(params: { dateFrom?: string; dateTo?: string }) {
@@ -385,27 +384,20 @@ class ApiService {
     return res.data?.data ?? [];
   }
 
-  async exportWarehouseStockXlsx(params: { dateFrom?: string; dateTo?: string }) {
+  async exportWarehouseStockXlsx(params: { date_from?: string; date_to?: string }) {
     const qs = new URLSearchParams();
-    if (params.dateFrom) qs.set('date_from', params.dateFrom);
-    if (params.dateTo) qs.set('date_to', params.dateTo);
-    qs.set('export', 'excel');
-    const response = await fetch(`${API_BASE_URL}/admin/warehouse/reports/stock?${qs.toString()}`);
-    const blob = await response.blob();
-    const disposition = response.headers.get('content-disposition');
-    let fileName = 'report.xlsx';
-    if (disposition) {
-      const match = /filename="?([^";]+)"?/i.exec(disposition);
-      if (match && match[1]) fileName = match[1];
-    }
-    const url = window.URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = fileName;
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    window.URL.revokeObjectURL(url);
+    if (params.date_from) qs.set('date_from', params.date_from);
+    if (params.date_to) qs.set('date_to', params.date_to);
+    const url = `${API_BASE_URL}/admin/warehouse/reports/stock?${qs.toString()}&export=excel`;
+    const res = await fetch(url, { credentials: 'include' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const blob = await res.blob();
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `warehouse_stock_${params.date_to || 'today'}.xlsx`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
   }
 
   async exportWarehouseArrivalsXlsx(params: { dateFrom?: string; dateTo?: string }) {

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,0 +1,12 @@
+export function formatDateTimeAlmaty(iso: string | Date) {
+  const d = typeof iso === 'string' ? new Date(iso) : iso;
+  return new Intl.DateTimeFormat('ru-RU', {
+    timeZone: 'Asia/Almaty',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(d);
+}


### PR DESCRIPTION
## Summary
- add robust warehouse stock report endpoint with Excel export and 400 error handling
- format dates in warehouse reports and move export button below results
- expose stock API helpers and datetime formatter on frontend

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bea0e1eb2883289f0dd7a3c9d1f7ee