### PR TITLE
Add warehouse dispatches report with Excel export and CORS fix

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -423,6 +423,31 @@ class ApiService {
     window.URL.revokeObjectURL(url);
   }
 
+  // Warehouse — Dispatches JSON
+  async getWarehouseDispatches(params: { date_from?: string; date_to?: string }) {
+    const qs = new URLSearchParams();
+    if (params.date_from) qs.set('date_from', params.date_from);
+    if (params.date_to) qs.set('date_to', params.date_to);
+    return this.request<any>(`/admin/warehouse/reports/dispatches?${qs.toString()}`);
+  }
+
+  // Warehouse — Dispatches Excel
+  async exportWarehouseDispatchesXlsx(params: { date_from?: string; date_to?: string }) {
+    const qs = new URLSearchParams();
+    if (params.date_from) qs.set('date_from', params.date_from);
+    if (params.date_to) qs.set('date_to', params.date_to);
+    const url = `${API_BASE_URL}/admin/warehouse/reports/dispatches?${qs.toString()}&export=excel`;
+    const res = await fetch(url, { credentials: 'include' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const blob = await res.blob();
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `warehouse_dispatches_${params.date_to || 'today'}.xlsx`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+
   // Categories (updated with type parameter)
   async getCategoriesByType(type?: string) {
     let url = '/categories';


### PR DESCRIPTION
## Summary
- add /admin/warehouse/reports/dispatches endpoint with JSON and Excel output
- expose Content-Disposition and use explicit CORS origins for credentialed downloads
- support dispatch report in frontend API and UI with details modal and Excel export

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bea54df59483288fae5b9085f6aba8